### PR TITLE
Auto bang commands

### DIFF
--- a/duckduckgo-test.el
+++ b/duckduckgo-test.el
@@ -17,4 +17,20 @@
               :to-contain
               '("!wolf" . "Wolfram Alpha")))))
 
+(describe "Parsing query possibly containing a bang"
+  (it "returns nil if no bang is contained"
+    (expect (duckduckgo--bang-query-p "hello bang")
+            :to-be nil)
+    (expect (duckduckgo--bang-query-p "hello bang!")
+            :to-be nil))
+  (it "returns the name of a bang if it contains a bang"
+    (expect (duckduckgo--bang-query-p "!hackage")
+            :to-equal "!hackage")
+    (expect (duckduckgo--bang-query-p "!hackage hoogle")
+            :to-equal "!hackage")
+    (expect (duckduckgo--bang-query-p "hoogle !hackage")
+            :to-equal "!hackage")
+    (expect (duckduckgo--bang-query-p "hoogle !hackage haskellwiki")
+            :to-equal "!hackage")))
+
 (provide 'duckduckgo-test)

--- a/duckduckgo.el
+++ b/duckduckgo.el
@@ -122,8 +122,16 @@
                         (format "Run %s." bang)))
                  (interactive "sQuery: ")
                  (duckduckgo-bang--run ,bang query))))
-    (fset sym body)
-    sym))
+    (catch 'set
+      (when (fboundp sym)
+        (if (called-interactively-p t)
+            (setq sym (intern (read-string
+                               (format "Function \"%s\" is already bound. Enter a new name: "
+                                       sym))))
+          (message "Function \"%s\" is already bound" sym)
+          (throw 'set nil)))
+      (fset sym body)
+      sym)))
 
 ;;;; Parsing the list of bangs
 


### PR DESCRIPTION
Added `duckduckgo-bang-define-commands` option. When this variable is non-nil, an interactive function is defined when a bang query is run.